### PR TITLE
Add environment-driven backend configuration

### DIFF
--- a/live-transcription-server/README.md
+++ b/live-transcription-server/README.md
@@ -11,7 +11,7 @@ The **Live Transcription Server** is a backend application built with FastAPI, d
 - **Scalable Architecture**: Utilizes worker threads and asynchronous programming to efficiently manage transcription requests.
 - **Audio Storage**: Saves audio chunks to the filesystem for record-keeping and further processing.
 - **Robust Error Handling**: Implements comprehensive logging and error handling to ensure reliability and ease of debugging.
-- **Configurable Environment**: Easily configurable through environment variables and runtime configurations.
+- **Configurable Environment**: Automatically loads settings from environment variables (including a local `.env` file).
 
 ## Prerequisites
 
@@ -46,9 +46,12 @@ The **Live Transcription Server** is a backend application built with FastAPI, d
    pip install -r requirements.txt
    ```
 
+   The backend automatically loads a `.env` file in this directory via [`python-dotenv`](https://pypi.org/project/python-dotenv/)
+   so you can override configuration without exporting variables manually.
+
 4. **Configure Environment Variables**
 
-   Create a `.env` file in the root directory to set up environment variables if necessary. For example:
+   Create a `.env` file in the root directory to set up environment variables. The server reads these values at startup:
 
    ```env
    # Server Configuration
@@ -56,12 +59,12 @@ The **Live Transcription Server** is a backend application built with FastAPI, d
    HOST=0.0.0.0  # Use 'localhost' for local development only
 
    # Application Configuration
-   TRANSCRIPTION_MODEL_ID=openai/whisper-large-v3-turbo
+   TRANSCRIPTION_MODEL_ID=openai/whisper-medium
    AUDIO_STORAGE_DIR=audio_chunks
    LOG_LEVEL=INFO
    ```
 
-   > **Note:** The default configuration is already set in the code. Adjust the `.env` file if you need to change the default settings.
+   > **Note:** The backend defaults to the `openai/whisper-medium` checkpoint, which fits comfortably in around 8&nbsp;GB of system RAM. Override `TRANSCRIPTION_MODEL_ID` in your `.env` only if you have hardware that can support a larger model.
 
 ## Running the Server
 
@@ -84,31 +87,110 @@ The server will be accessible at `http://localhost:<PORT>` (e.g., `http://localh
 
 ### Production
 
-For production deployment, it's recommended to use a production-ready ASGI server like **Gunicorn** with **Uvicorn** workers.
+For production deployment, it's recommended to use a production-ready ASGI server like **Gunicorn** with **Uvicorn** workers. Adjust the number of workers so that the Whisper checkpoint and its activations comfortably fit in memory.
 
-1. **Install Gunicorn**
+#### Debian 12 (8 cores / 8&nbsp;GB RAM) deployment guide
+
+The following checklist assumes a fresh Debian 12 server with 8 CPU cores and 8&nbsp;GB of RAM.
+
+1. **Install system packages**
 
    ```bash
+   sudo apt update
+   sudo apt install -y python3 python3-venv python3-pip build-essential ffmpeg
+   ```
+
+   `ffmpeg` is required for audio preprocessing by the Transformers pipeline.
+
+2. **Create application directory**
+
+   ```bash
+   sudo mkdir -p /opt/live-transcription
+   sudo chown "$USER":"$USER" /opt/live-transcription
+   cd /opt/live-transcription
+   ```
+
+3. **Clone the repository and set up Python**
+
+   ```bash
+   git clone https://github.com/yourusername/live-transcription-server.git .
+   python3 -m venv .venv
+   source .venv/bin/activate
+   pip install --upgrade pip
+   pip install -r requirements.txt
    pip install gunicorn
    ```
 
-2. **Run the Server with Gunicorn**
+4. **Create a production `.env`**
 
-   ```bash
-   # Using default port (8000)
-   gunicorn main:app -k uvicorn.workers.UvicornWorker --bind 0.0.0.0:8000 --workers 4
-
-   # Using custom port
-   gunicorn main:app -k uvicorn.workers.UvicornWorker --bind 0.0.0.0:8080 --workers 4
-
-   # Using environment variables
-   gunicorn main:app -k uvicorn.workers.UvicornWorker --bind 0.0.0.0:$PORT --workers 4
+   ```env
+   HOST=0.0.0.0
+   PORT=8000
+   TRANSCRIPTION_MODEL_ID=openai/whisper-medium
+   AUDIO_STORAGE_DIR=/opt/live-transcription/audio_chunks
+   LOG_LEVEL=INFO
    ```
 
-   Adjust the number of `--workers` based on your server's CPU cores.
+   With only 8&nbsp;GB of RAM, stick with the medium model and keep Gunicorn workers to 1–2 (see below) to avoid memory pressure.
+
+5. **Prepare storage and permissions**
+
+   ```bash
+   mkdir -p /opt/live-transcription/audio_chunks
+   chmod 750 /opt/live-transcription/audio_chunks
+   ```
+
+6. **Launch Gunicorn with conservative workers**
+
+   ```bash
+   source /opt/live-transcription/.venv/bin/activate
+   cd /opt/live-transcription
+   gunicorn main:app \
+     -k uvicorn.workers.UvicornWorker \
+     --bind "${HOST:-0.0.0.0}:${PORT:-8000}" \
+     --workers 2 \
+     --timeout 120
+   ```
+
+   Two workers balance CPU utilization against the memory footprint of the Whisper medium model. If the server starts swapping, drop to a single worker.
+
+7. **Optional: Create a systemd service**
+
+   ```ini
+   # /etc/systemd/system/live-transcription.service
+   [Unit]
+   Description=Live Transcription Backend
+   After=network.target
+
+   [Service]
+   Type=simple
+   WorkingDirectory=/opt/live-transcription
+   EnvironmentFile=/opt/live-transcription/.env
+   ExecStart=/opt/live-transcription/.venv/bin/gunicorn main:app \
+     -k uvicorn.workers.UvicornWorker \
+     --bind 0.0.0.0:${PORT} \
+     --workers=2 \
+     --timeout=120
+   Restart=always
+   User=www-data
+   Group=www-data
+
+   [Install]
+   WantedBy=multi-user.target
+   ```
+
+   Enable and start the service:
+
+   ```bash
+   sudo systemctl daemon-reload
+   sudo systemctl enable --now live-transcription.service
+   ```
+
+These steps provide a production-ready deployment tailored to commodity Debian 12 hardware without a discrete GPU. Increase the worker count or switch to a larger Whisper model only after upgrading the memory footprint of the host.
 
 ## Project Structure
 
+- `config.py`: Centralizes environment-driven configuration and logging defaults.
 - `main.py`: Entry point for the FastAPI application.
 - `real_time_audio/`: Contains modules related to real-time audio processing.
   - `__init__.py`: Initializes the transcription handler.

--- a/live-transcription-server/README.md
+++ b/live-transcription-server/README.md
@@ -186,6 +186,51 @@ The following checklist assumes a fresh Debian 12 server with 8 CPU cores and 8&
    sudo systemctl enable --now live-transcription.service
    ```
 
+8. **Optional: Place Nginx in front as a reverse proxy**
+
+   Add Nginx if you want to terminate TLS, serve static assets, or expose the API on ports 80/443 while keeping Gunicorn bound to localhost.
+
+   ```bash
+   sudo apt install -y nginx
+   sudo rm /etc/nginx/sites-enabled/default
+   ```
+
+   Create `/etc/nginx/sites-available/live-transcription` with the following contents:
+
+   ```nginx
+   upstream live_transcription_backend {
+       server 127.0.0.1:8000;
+   }
+
+   server {
+       listen 80;
+       server_name your.domain.example;
+
+       # Increase limits for websocket audio frames.
+       client_max_body_size 50M;
+
+       location / {
+           proxy_pass http://live_transcription_backend;
+           proxy_http_version 1.1;
+           proxy_set_header Upgrade $http_upgrade;
+           proxy_set_header Connection "upgrade";
+           proxy_set_header Host $host;
+           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+           proxy_set_header X-Forwarded-Proto $scheme;
+       }
+   }
+   ```
+
+   Enable the site and reload Nginx:
+
+   ```bash
+   sudo ln -s /etc/nginx/sites-available/live-transcription /etc/nginx/sites-enabled/
+   sudo nginx -t
+   sudo systemctl reload nginx
+   ```
+
+   For HTTPS, obtain certificates (for example with [Certbot](https://certbot.eff.org/)) and update the `server` block to listen on `443 ssl`.
+
 These steps provide a production-ready deployment tailored to commodity Debian 12 hardware without a discrete GPU. Increase the worker count or switch to a larger Whisper model only after upgrading the memory footprint of the host.
 
 ## Project Structure

--- a/live-transcription-server/config.py
+++ b/live-transcription-server/config.py
@@ -1,0 +1,78 @@
+"""Application configuration loaded from environment variables."""
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+# Load variables from a local .env file if present.
+load_dotenv()
+
+
+def _as_int(value: str | None, default: int) -> int:
+    try:
+        return int(value) if value is not None else default
+    except ValueError:
+        return default
+
+
+def _as_log_level(value: str | None, default: int = logging.INFO) -> int:
+    if not value:
+        return default
+    level = logging.getLevelName(value.upper())
+    # logging.getLevelName returns the numeric level when it recognizes the name,
+    # otherwise it echoes back the input string. Guard for that case.
+    return level if isinstance(level, int) else default
+
+
+@dataclass(frozen=True)
+class Settings:
+    """Immutable settings object with sane defaults."""
+
+    host: str
+    port: int
+    transcription_model_id: str
+    audio_storage_dir: Path
+    log_level: int
+
+    @property
+    def log_level_name(self) -> str:
+        return logging.getLevelName(self.log_level)
+
+
+@lru_cache(maxsize=1)
+def get_settings() -> Settings:
+    """Read configuration from environment variables once per process."""
+
+    settings = Settings(
+        host=os.getenv("HOST", "0.0.0.0"),
+        port=_as_int(os.getenv("PORT"), 8000),
+        transcription_model_id=os.getenv(
+            "TRANSCRIPTION_MODEL_ID", "openai/whisper-medium"
+        ),
+        audio_storage_dir=Path(os.getenv("AUDIO_STORAGE_DIR", "audio_chunks")),
+        log_level=_as_log_level(os.getenv("LOG_LEVEL")),
+    )
+
+    # Ensure the audio storage directory exists early in the lifecycle.
+    settings.audio_storage_dir.mkdir(parents=True, exist_ok=True)
+
+    logging.basicConfig(level=settings.log_level)
+    logging.getLogger(__name__).debug(
+        "Loaded settings: host=%s port=%s model=%s audio_dir=%s log_level=%s",
+        settings.host,
+        settings.port,
+        settings.transcription_model_id,
+        settings.audio_storage_dir,
+        settings.log_level_name,
+    )
+
+    return settings
+
+
+# Instantiate settings at import time so other modules can simply import `settings`.
+settings = get_settings()

--- a/live-transcription-server/main.py
+++ b/live-transcription-server/main.py
@@ -1,9 +1,22 @@
+import logging
+
 from fastapi import FastAPI
+
+from config import settings  # noqa: F401 ensures env config loads before routes
 from real_time_audio.routes import router as audio_router
 
 app = FastAPI()
 
 app.include_router(audio_router)
+
+
+@app.on_event("startup")
+async def log_startup_configuration() -> None:
+    logging.getLogger(__name__).info(
+        "Live Transcription Server starting with model '%s' and audio dir '%s'",
+        settings.transcription_model_id,
+        settings.audio_storage_dir,
+    )
 
 # To run the server, use the command:
 # uvicorn main:app --reload

--- a/live-transcription-server/real_time_audio/handler.py
+++ b/live-transcription-server/real_time_audio/handler.py
@@ -1,19 +1,18 @@
 import asyncio
+import logging
 import queue
 import threading
 import time
 import uuid
-import logging
 from datetime import datetime
-from pathlib import Path
 from typing import Dict, NamedTuple
 
 from fastapi import WebSocket
 
 from .service import TranscriptionService
+from config import settings
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.INFO)
 
 # Audio parameters - must match frontend MediaRecorder settings
 CHANNELS = 1
@@ -21,9 +20,7 @@ SAMPLE_WIDTH = 2  # 16-bit audio
 SAMPLE_RATE = 16000
 
 # Audio storage configuration
-AUDIO_STORAGE_DIR = Path("audio_chunks")
-if not AUDIO_STORAGE_DIR.exists():
-    AUDIO_STORAGE_DIR.mkdir(parents=True, exist_ok=True)
+AUDIO_STORAGE_DIR = settings.audio_storage_dir
 
 
 class TranscriptionRequest(NamedTuple):

--- a/live-transcription-server/real_time_audio/service.py
+++ b/live-transcription-server/real_time_audio/service.py
@@ -1,17 +1,19 @@
-import torch
-from transformers import AutoModelForSpeechSeq2Seq, AutoProcessor, pipeline
 import logging
+import platform
 import time
 from datetime import datetime
-import platform
+
+import torch
+from transformers import AutoModelForSpeechSeq2Seq, AutoProcessor, pipeline
+
+from config import settings
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.INFO)
 
 class TranscriptionService:
     def __init__(self):
         self.device, self.torch_dtype = self._setup_device_and_dtype()
-        model_id = "openai/whisper-large-v3-turbo"  # Using the large turbo model
+        model_id = settings.transcription_model_id
 
         try:
             self.model = AutoModelForSpeechSeq2Seq.from_pretrained(

--- a/live-transcription-server/requirements.txt
+++ b/live-transcription-server/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn[standard]
 sentence-transformers==3.0.1
 accelerate==0.26.0
+python-dotenv


### PR DESCRIPTION
## Summary
- load backend settings from environment variables (including `.env`) via a shared configuration module
- wire the transcription service and handlers to respect the configured model and audio storage path, and log startup configuration
- document the new configuration workflow in the backend README and add the required `python-dotenv` dependency

## Testing
- python -m compileall live-transcription-server

------
https://chatgpt.com/codex/tasks/task_b_68d538825b4c832a9a1d5b36e8118ae6