### PR TITLE
Fix async WebSocket handling and update payload docs

### DIFF
--- a/live-transcription-server/README.md
+++ b/live-transcription-server/README.md
@@ -85,6 +85,114 @@ uvicorn main:app --reload --port $PORT
 
 The server will be accessible at `http://localhost:<PORT>` (e.g., `http://localhost:8000` or your custom port).
 
+#### Quick WebSocket connectivity check (public test)
+
+For quick smoke-testing against a publicly reachable deployment you can open a browser console and initiate a WebSocket
+session directly. The snippet below connects to the sample deployment running at `ws://103.125.255.109/ws/transcribe` and
+logs connection lifecycle events:
+
+```js
+const socket = new WebSocket('ws://103.125.255.109/ws/transcribe');
+
+socket.addEventListener('open', () => {
+  console.log('✅ Connected to live transcription backend');
+  // TODO: send encoded audio chunks once you are ready
+});
+
+socket.addEventListener('message', (event) => {
+  console.log('Transcription update:', event.data);
+});
+
+socket.addEventListener('close', (event) => {
+  console.log('Connection closed', event.code, event.reason);
+});
+
+socket.addEventListener('error', (event) => {
+  console.error('WebSocket error', event);
+});
+```
+
+> **Note:** The backend keeps the socket open until it receives audio data, so the snippet above is only a connectivity
+> smoke test. Keep the socket open and send binary WAV frames (see the next section) to exercise the full pipeline.
+
+#### WebSocket payload contract
+
+The `/ws/transcribe` endpoint expects each message to be a binary frame containing a complete WAV-formatted audio chunk
+that matches the capture parameters used across the project:
+
+- **Sample rate:** 16&nbsp;kHz
+- **Channels:** mono (1)
+- **Sample width:** 16-bit little-endian (PCM)
+
+Each chunk is forwarded to the Whisper pipeline as soon as it is saved, and transcription results are streamed back to the
+client as JSON objects of the form:
+
+```json
+{
+  "type": "transcription",
+  "text": "<recognized text>",
+  "timestamp": 1714059673.123,
+  "audio_file": "/abs/path/to/chunk.wav"
+}
+```
+
+Because the server expects binary frames, make sure to set `socket.binaryType = 'arraybuffer'` before you start sending data
+from the browser. The example below records microphone input with the `MediaRecorder` API, converts each chunk to a WAV blob
+using the agreed 16&nbsp;kHz mono profile, and streams it to the backend:
+
+```js
+const socket = new WebSocket('ws://103.125.255.109/ws/transcribe');
+socket.binaryType = 'arraybuffer';
+
+async function startStreaming() {
+  const mediaStream = await navigator.mediaDevices.getUserMedia({ audio: true });
+  const recorder = new MediaRecorder(mediaStream, {
+    mimeType: 'audio/wav',
+    audioBitsPerSecond: 128000,
+  });
+
+  recorder.addEventListener('dataavailable', async (event) => {
+    if (event.data.size === 0 || socket.readyState !== WebSocket.OPEN) {
+      return;
+    }
+
+    const arrayBuffer = await event.data.arrayBuffer();
+    socket.send(arrayBuffer);
+  });
+
+  recorder.start(1000); // emit a chunk every second
+}
+
+socket.addEventListener('open', () => {
+  console.log('WebSocket connected, starting microphone capture…');
+  startStreaming().catch((error) => console.error('Recorder error', error));
+});
+```
+
+> **Heads-up:** Not every browser can generate `audio/wav` chunks directly. If `MediaRecorder` throws a `NotSupportedError`,
+> fall back to a WAV encoder library (for example [`wavefile`](https://www.npmjs.com/package/wavefile)) to transcode the raw
+> PCM samples emitted by `audio/webm` or `audio/ogg` blobs before calling `socket.send()`.
+
+If you're testing outside of the browser, an equivalent result can be achieved with Python:
+
+```python
+import asyncio
+import websockets
+
+async def send_wav(path: str):
+    async with websockets.connect('ws://103.125.255.109/ws/transcribe') as ws:
+        with open(path, 'rb') as wav_file:
+            await ws.send(wav_file.read())
+        print(await ws.recv())
+
+asyncio.run(send_wav('sample.wav'))
+```
+
+Install the dependency with `pip install websockets` if it is not already available in your environment.
+
+The Python example sends a single WAV file and prints the first transcription update it receives. Replace `sample.wav` with
+any 16&nbsp;kHz mono test clip that follows the same PCM encoding.
+
 ### Production
 
 For production deployment, it's recommended to use a production-ready ASGI server like **Gunicorn** with **Uvicorn** workers. Adjust the number of workers so that the Whisper checkpoint and its activations comfortably fit in memory.

--- a/live-transcription-server/real_time_audio/handler.py
+++ b/live-transcription-server/real_time_audio/handler.py
@@ -5,7 +5,7 @@ import threading
 import time
 import uuid
 from datetime import datetime
-from typing import Dict, NamedTuple
+from typing import Dict, NamedTuple, Optional
 
 from fastapi import WebSocket
 
@@ -33,12 +33,17 @@ class TranscriptionRequest(NamedTuple):
 
 class TranscriptionWorker(threading.Thread):
     """Single worker thread that processes all transcription requests sequentially"""
-    def __init__(self, transcription_service: TranscriptionService, loop: asyncio.AbstractEventLoop):
+
+    def __init__(self, transcription_service: TranscriptionService):
         super().__init__()
         self.transcription_service = transcription_service
         self.request_queue = queue.Queue(maxsize=100)
         self.result_queues: Dict[str, asyncio.Queue] = {}
         self.running = True
+        self.loop: Optional[asyncio.AbstractEventLoop] = None
+
+    def set_loop(self, loop: asyncio.AbstractEventLoop) -> None:
+        """Update the event loop used for delivering transcription results."""
         self.loop = loop
 
     def run(self):
@@ -61,15 +66,21 @@ class TranscriptionWorker(threading.Thread):
                     # If session still exists, send result
                     if request.session_id in self.result_queues:
                         result_queue = self.result_queues[request.session_id]
-                        asyncio.run_coroutine_threadsafe(
-                            result_queue.put({
-                                "type": "transcription",
-                                "text": transcription,
-                                "timestamp": request.timestamp,
-                                "audio_file": request.audio_file_path
-                            }),
-                            self.loop
-                        )
+                        if self.loop and not self.loop.is_closed():
+                            asyncio.run_coroutine_threadsafe(
+                                result_queue.put({
+                                    "type": "transcription",
+                                    "text": transcription,
+                                    "timestamp": request.timestamp,
+                                    "audio_file": request.audio_file_path
+                                }),
+                                self.loop,
+                            )
+                        else:
+                            logger.warning(
+                                "No active event loop available for session %s; dropping transcription result.",
+                                request.session_id,
+                            )
                 except Exception as e:
                     logger.error(f"Error processing transcription: {e}")
 
@@ -149,16 +160,9 @@ class TranscriptionHandler:
         self.active_connections: Dict[str, WebSocket] = {}
         self.output_queues: Dict[str, asyncio.Queue] = {}
         
-        try:
-            self.loop = asyncio.get_event_loop()
-            if self.loop.is_closed():
-                self.loop = asyncio.new_event_loop()
-                asyncio.set_event_loop(self.loop)
-        except RuntimeError:
-            self.loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(self.loop)
-        
-        self.worker = TranscriptionWorker(self.transcription_service, self.loop)
+        self.loop: Optional[asyncio.AbstractEventLoop] = None
+
+        self.worker = TranscriptionWorker(self.transcription_service)
         self.worker.start()
 
         # Initialize audio save worker
@@ -174,6 +178,10 @@ class TranscriptionHandler:
 
         session_id = str(uuid.uuid4())
         self.active_connections[session_id] = websocket
+
+        loop = asyncio.get_running_loop()
+        self.loop = loop
+        self.worker.set_loop(loop)
 
         # Initialize output queue and add to worker
         self.output_queues[session_id] = asyncio.Queue(maxsize=100)
@@ -205,8 +213,8 @@ class TranscriptionHandler:
                     # Enqueue the save request
                     self.audio_save_queue.put_nowait((session_id, audio_data, current_timestamp, response_queue))
                     
-                    # Wait for the file path to be saved
-                    audio_file_path = response_queue.get()
+                    # Wait for the file path to be saved without blocking the event loop
+                    audio_file_path = await asyncio.to_thread(response_queue.get)
                     
                     if audio_file_path is None:
                         raise Exception("Failed to save audio chunk.")


### PR DESCRIPTION
## Summary
- defer event-loop capture until a WebSocket connects so run_coroutine_threadsafe targets the live loop
- avoid blocking the FastAPI event loop while waiting for audio chunks to flush to disk
- document the binary WAV payload contract and provide end-to-end upload examples

## Testing
- python -m compileall live-transcription-server

------
https://chatgpt.com/codex/tasks/task_b_68d75f454640832aa56a392dbdd652c7